### PR TITLE
Fix clipboard not being read in some cases

### DIFF
--- a/src/main/clipboard.ts
+++ b/src/main/clipboard.ts
@@ -94,10 +94,15 @@ export const getNextFileNumber = async (syncFolder: string) => {
   return 1;
 };
 
-export const isThereMoreThanOneClipboardFile = async (syncFolder: string) => {
+export const isThereMoreThanOneClipboardFile = async (
+  syncFolder: string,
+  filter: "none" | "from-others" | "from-myself" = "none"
+) => {
   const files = await fs.readdir(syncFolder);
   for (const file of files) {
-    if (parseClipboardFileName(path.join(syncFolder, file), syncFolder)) {
+    if (
+      parseClipboardFileName(path.join(syncFolder, file), syncFolder, filter)
+    ) {
       return true;
     }
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -366,7 +366,7 @@ const readClipboardFromFile = async (parsedFile: ParsedClipboardFileName) => {
   // Skips the read if a newer clipboard was already sent, which can happen if
   // OneDrive takes too long to sync
   if (
-    isThereMoreThanOneClipboardFile(syncFolder) &&
+    isThereMoreThanOneClipboardFile(syncFolder, "from-myself") &&
     lastFileNumberWritten &&
     currentFileNumber < lastFileNumberWritten
   ) {


### PR DESCRIPTION
This situation can happen in the last file written was like 50, but it got deleted and then remote server starts from an older number like 1.
