### PR TITLE
Replace electron-clipboard-ex with clip-filepaths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3",
+        "clip-filepaths": "^0.2.0",
         "clipboard-event": "^1.6.0",
         "electron-log": "^5.4.0",
         "electron-squirrel-startup": "^1.0.1",
@@ -37,9 +38,6 @@
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
         "vite": "^6.3.5"
-      },
-      "optionalDependencies": {
-        "electron-clipboard-ex": "^1.3.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4140,6 +4138,153 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/clip-filepaths": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/clip-filepaths/-/clip-filepaths-0.2.0.tgz",
+      "integrity": "sha512-O604SxQJP1/OdrPJfKiyAswXFMw1nFCT1SixhhoZL0TfTKrwbM1zFnUf9DOdpbDovvLZIxXgP7gihjA03y9hbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "clip-filepaths-darwin-arm64": "0.2.0",
+        "clip-filepaths-darwin-x64": "0.2.0",
+        "clip-filepaths-linux-arm64-gnu": "0.2.0",
+        "clip-filepaths-linux-arm64-musl": "0.2.0",
+        "clip-filepaths-linux-x64-gnu": "0.2.0",
+        "clip-filepaths-linux-x64-musl": "0.2.0",
+        "clip-filepaths-win32-arm64-msvc": "0.2.0",
+        "clip-filepaths-win32-x64-msvc": "0.2.0"
+      }
+    },
+    "node_modules/clip-filepaths-darwin-arm64": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/clip-filepaths-darwin-arm64/-/clip-filepaths-darwin-arm64-0.2.0.tgz",
+      "integrity": "sha512-fpi/PKMFZowoRap28Dhv1/45s2/XolfrPWpQrQqxdgT6kXnDfMPWC+XayyHLx2jItLWCtRJ/+XrUDdCqL1hOwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/clip-filepaths-darwin-x64": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/clip-filepaths-darwin-x64/-/clip-filepaths-darwin-x64-0.2.0.tgz",
+      "integrity": "sha512-Y5rfbxGOfOLxqLIn45tHcU6GDl9rqJFqbt3LrsKtyRWMFM4Z+ALmZv5/jDgo6iBfmXpnnKfnr/+BdbsrCfkCgQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/clip-filepaths-linux-arm64-gnu": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/clip-filepaths-linux-arm64-gnu/-/clip-filepaths-linux-arm64-gnu-0.2.0.tgz",
+      "integrity": "sha512-Dk0NMltqOsA8aMpFFX9FeTpwz4CsXwLAU9lA2ql3QvI4MFXBYDry9wBGQ0WgQGo+WUlIq0wnN8phAQUxSenuVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/clip-filepaths-linux-arm64-musl": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/clip-filepaths-linux-arm64-musl/-/clip-filepaths-linux-arm64-musl-0.2.0.tgz",
+      "integrity": "sha512-KEo+qNe78G+xf6yYrmlBfVCa7S4EQu5yYo8veG2wnpAqg/BJjLGvgR7iqGcaddcsPPnZnXBBBoyQPNiXxuZQQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/clip-filepaths-linux-x64-gnu": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/clip-filepaths-linux-x64-gnu/-/clip-filepaths-linux-x64-gnu-0.2.0.tgz",
+      "integrity": "sha512-qnN9+Mt6OUv4A22rS/xNC+OUSm8DQX/muyovrZXOsWhbS2LiNb/JTA4jicC/kuhl/7FaeEGpX/QuM5zq3PoB2w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/clip-filepaths-linux-x64-musl": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/clip-filepaths-linux-x64-musl/-/clip-filepaths-linux-x64-musl-0.2.0.tgz",
+      "integrity": "sha512-MWXmDQNQiqRwhNSs4Av9QRDSWUNr/IRK74fQA1JMu/PhasYh+d9Ap6hXoWy+GFNAl6kN7BAmEWK5sNTTYz2+cw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/clip-filepaths-win32-arm64-msvc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/clip-filepaths-win32-arm64-msvc/-/clip-filepaths-win32-arm64-msvc-0.2.0.tgz",
+      "integrity": "sha512-XFmXBCvGGMffn3Li+fHJyiNUcDt4AeTbz4DAlglRNY4Ky6lKLLDGZQE6en0g4CZWN89IFgbrg3tzN/t3fYhwTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/clip-filepaths-win32-x64-msvc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/clip-filepaths-win32-x64-msvc/-/clip-filepaths-win32-x64-msvc-0.2.0.tgz",
+      "integrity": "sha512-TGvtigBGZjNoOlpxBhlvcfgBPvtwIzbeSlPNoy4CWWbYUkZF8jAAsYitefJclW8k4fhpXPytmQAdPoZrextt4w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/clipboard-event": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/clipboard-event/-/clipboard-event-1.6.0.tgz",
@@ -4764,22 +4909,6 @@
       },
       "engines": {
         "node": ">= 12.20.55"
-      }
-    },
-    "node_modules/electron-clipboard-ex": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/electron-clipboard-ex/-/electron-clipboard-ex-1.3.3.tgz",
-      "integrity": "sha512-bny+IQhbLd7ur4NMKJ6P9+WRG2KTF6yGrbKem2N/zIdK64Yk3hCqVEiuyON6b2aOeEUDGkvS8LCkk4Q2IimehA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin",
-        "win32"
-      ],
-      "dependencies": {
-        "node-addon-api": "^4.0.0",
-        "node-gyp-build": "^4.2.3"
       }
     },
     "node_modules/electron-installer-dmg": {
@@ -8657,13 +8786,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/node-addon-api": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/node-api-version": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
@@ -8702,18 +8824,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "repository": "https://github.com/felipecrs/clipboard-sync.git",
   "dependencies": {
     "chokidar": "^4.0.3",
+    "clip-filepaths": "^0.2.0",
     "clipboard-event": "^1.6.0",
     "electron-log": "^5.4.0",
     "electron-squirrel-startup": "^1.0.1",
@@ -52,9 +53,6 @@
     "rimraf": "^6.0.1",
     "typescript": "^5.8.3",
     "vite": "^6.3.5"
-  },
-  "optionalDependencies": {
-    "electron-clipboard-ex": "^1.3.3"
   },
   "volta": {
     "node": "22.15.0",


### PR DESCRIPTION
`clip-filepaths` supports Linux and `electron-clipboard-ex` did not. However, I only tried it on Windows.

Thanks to @tktcorporation for implementing the missing read function.

Refs https://github.com/tktcorporation/clip-filepaths/issues/18